### PR TITLE
Temporarily disabled ME Connector logging

### DIFF
--- a/src/Lykke.Service.HFT/Modules/MatchingEngineModule.cs
+++ b/src/Lykke.Service.HFT/Modules/MatchingEngineModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Autofac;
+using Common;
 using Common.Log;
 using JetBrains.Annotations;
 using Lykke.MatchingEngine.Connector.Services;
@@ -28,8 +29,7 @@ namespace Lykke.Service.HFT.Modules
 
         protected override void Load(ContainerBuilder builder)
         {
-            var meVersion = typeof(SocketLogDynamic).Assembly.GetName().Version.ToString();
-            var socketLog = new SocketLogDynamic(i => { }, str => _log.WriteInfoAsync($"ME connector {meVersion}", "socket log", str).Wait());
+            var socketLog = new SocketLogDynamic(i => { }, str => Console.WriteLine(DateTime.UtcNow.ToIsoDateTime() + ": " + str));
 
             builder.BindMeClient(_settings.CurrentValue.IpEndpoint.GetClientIpEndPoint(), socketLog);
 


### PR DESCRIPTION
https://lykkex.atlassian.net/browse/LWDEV-4579
**Task.** Temporarily disable ME Connector logging due to a lot of error messages in logger. The main problem is detected, and will be fixed soon.
**Fix.** Temporarily disabled ME Connector logging using main service logger. Console output is still used.