### PR TITLE
LWDEV-7769 : Cancel all open limit orders

### DIFF
--- a/src/Lykke.Service.HFT.Core/Services/IMatchingEngineAdapter.cs
+++ b/src/Lykke.Service.HFT.Core/Services/IMatchingEngineAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Lykke.Service.Assets.Client.Models;
 using Lykke.Service.HFT.Core.Domain;
@@ -8,7 +9,9 @@ namespace Lykke.Service.HFT.Core.Services
     public interface IMatchingEngineAdapter
     {
         Task<ResponseModel> CancelLimitOrderAsync(Guid limitOrderId);
+        Task<ResponseModel> CancelAllAsync(string clientId, AssetPair pair, bool? isBuy);
         Task<ResponseModel<double>> HandleMarketOrderAsync(string clientId, AssetPair assetPair, OrderAction orderAction, double volume, bool straight, double? reservedLimitVolume = default(double?));
         Task<ResponseModel<Guid>> PlaceLimitOrderAsync(string clientId, AssetPair assetPair, OrderAction orderAction, double volume, double price, bool cancelPreviousOrders = false);
+
     }
 }

--- a/src/Lykke.Service.HFT/Models/Requests/Side.cs
+++ b/src/Lykke.Service.HFT/Models/Requests/Side.cs
@@ -1,0 +1,23 @@
+﻿namespace Lykke.Service.HFT.Models.Requests
+{
+    /// <summary>
+    /// Side enumeration describing the type of orders to query.
+    /// </summary>
+    public enum Side
+    {
+        /// <summary>
+        /// Both types of orders (Buy and Sell)
+        /// </summary>
+        Both,
+
+        /// <summary>
+        /// Buy orders
+        /// </summary>
+        Buy,
+
+        /// <summary>
+        /// Sell orders
+        /// </summary>
+        Sell
+    }
+}


### PR DESCRIPTION
https://lykkex.atlassian.net/browse/LWDEV-7769

- Added support for cancel all httpdelete (optional assetpair & buy/sell/both)
- Made post cancel by {id}/cancel obsolete
- Added httpdelete {id} to cancel a limit order (old http-post {id}/cancel)
- Included pending state in open orders query