### PR TITLE
Fixed bug: minimal DateTime value in Azure Table Storage

### DIFF
--- a/src/Lykke.Service.HFT/PeriodicalHandlers/OrderStateArchiver.cs
+++ b/src/Lykke.Service.HFT/PeriodicalHandlers/OrderStateArchiver.cs
@@ -7,6 +7,7 @@ using Common;
 using Common.Log;
 using Lykke.Service.HFT.Core.Domain;
 using Lykke.Service.HFT.Core.Repositories;
+using MoreLinq;
 
 namespace Lykke.Service.HFT.PeriodicalHandlers
 {
@@ -14,6 +15,7 @@ namespace Lykke.Service.HFT.PeriodicalHandlers
     {
         private const int DefaultChunkSize = 5000;
         private const int MinimalChunkSize = 100;
+        private static readonly DateTime MinimalTime = new DateTime(1601, 1, 1);
         private readonly ILog _log;
         private readonly TimeSpan _activeOrdersWindow;
         private readonly IRepository<LimitOrderState> _orderStateCache;
@@ -64,6 +66,8 @@ namespace Lykke.Service.HFT.PeriodicalHandlers
                     _log.WriteInfo("OrderStateArchiver", null, $"2. Got {notActiveOrders.Count} orders in {sw.Elapsed.TotalSeconds} sec.");
                     sw.Restart();
 
+                    notActiveOrders.Where(x => x.CreatedAt < MinimalTime).ForEach(x => x.CreatedAt = MinimalTime);
+                    notActiveOrders.Where(x => x.Registered < MinimalTime).ForEach(x => x.Registered = MinimalTime);
                     await _orderStateArchive.AddAsync(notActiveOrders);
                     _log.WriteInfo("OrderStateArchiver", null, $"3. Migrated to azure in {sw.Elapsed.TotalMinutes} min.");
                     sw.Restart();


### PR DESCRIPTION
Minimal DateTime value in Azure Table Storage is DateTime(1601, 1, 1).
https://lykkex.atlassian.net/browse/LWDEV-8132